### PR TITLE
Memory leak fixes

### DIFF
--- a/ReaderWriter/OVFReaderWriter/FileReaderWriter/OVFFileWriter.cs
+++ b/ReaderWriter/OVFReaderWriter/FileReaderWriter/OVFFileWriter.cs
@@ -193,7 +193,7 @@ namespace OpenVectorFormat.OVFReaderWriter
                     progress.IsFinished = true;
                 }
             }
-            _fs?.Close();
+            _fs?.Dispose();
             _fs = null;
             _currentWorkPlaneShell = null;
             _jobLUT = null;


### PR DESCRIPTION
Fixed several memory leaks in OVFFileReader related to not disposing local streams of workplanes, thus leaving unmanaged resources in memory. Fixed dispose function to also dispose the MMF.
Tests looked good locally, but this is a change in some critical code part. Please review if I missed any problems.