### PR TITLE
Update .gitmodules to use relative path so gitlab CI can recurse into this repos submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "submodules/OpenVectorFormat"]
 	path = submodules/OpenVectorFormat
-	url = git@github.com:Digital-Production-Aachen/OpenVectorFormat.git
+	url = ../OpenVectorFormat.git


### PR DESCRIPTION
Change submodules/OpenVectorFormat to use relative repository path in .gitmodules. This is required by gitlab CI (gitrunner) that all submodules are referred relatively

It is very stupid that gitlab can only recursively clone a repo but here is the reference https://docs.gitlab.com/ee/ci/git_submodules.html#configuring-the-gitmodules-file