### PR TITLE
Upgrading .net versions

### DIFF
--- a/.github/workflows/BuildTestDeploy.yml
+++ b/.github/workflows/BuildTestDeploy.yml
@@ -43,14 +43,14 @@ jobs:
     - name: Test Linux
       if: contains(matrix.os, 'ubuntu')
       run: |
-        dotnet build --configuration Release --framework netcoreapp2.1 ReaderWriter/FileReaderWriterFactoryGRPCWrapper/FileReaderWriterFactoryGRPCWrapper.csproj
-        dotnet build --configuration Release --framework netcoreapp2.1 ReaderWriter/UnitTests/UnitTests.csproj
-        dotnet build --configuration Release --framework netcoreapp2.1 PlausibilityChecker/PlausibilityCheckerUnitTests/PlausibilityCheckerUnitTests.csproj
-        dotnet run --configuration Release --framework netcoreapp2.1 --project ReaderWriter/FileReaderWriterFactoryGRPCWrapper/FileReaderWriterFactoryGRPCWrapper.csproj background &
+        dotnet build --configuration Release --framework net6 ReaderWriter/FileReaderWriterFactoryGRPCWrapper/FileReaderWriterFactoryGRPCWrapper.csproj
+        dotnet build --configuration Release --framework net6 ReaderWriter/UnitTests/UnitTests.csproj
+        dotnet build --configuration Release --framework net6 PlausibilityChecker/PlausibilityCheckerUnitTests/PlausibilityCheckerUnitTests.csproj
+        dotnet run --configuration Release --framework net6 --project ReaderWriter/FileReaderWriterFactoryGRPCWrapper/FileReaderWriterFactoryGRPCWrapper.csproj background &
         grpcpid="$!"
         echo "started grpc server"
         sleep 5s
-        dotnet test --no-build --configuration Release --framework netcoreapp2.1
+        dotnet test --no-build --configuration Release --framework net6
         kill $grpcpid
         
     - name: Add msbuild to PATH
@@ -61,7 +61,7 @@ jobs:
       if: contains(matrix.os, 'windows')
       run: |
         dotnet build --configuration Release
-        $j = Start-Process -PassThru -Filepath 'dotnet' -WorkingDirectory $PWD -ArgumentList 'run --configuration Release --framework netcoreapp2.1 --project .\ReaderWriter\FileReaderWriterFactoryGRPCWrapper\FileReaderWriterFactoryGRPCWrapper.csproj background'
+        $j = Start-Process -PassThru -Filepath 'dotnet' -WorkingDirectory $PWD -ArgumentList 'run --configuration Release --framework net6 --project .\ReaderWriter\FileReaderWriterFactoryGRPCWrapper\FileReaderWriterFactoryGRPCWrapper.csproj background'
         Start-Sleep -s 5
         dotnet test --no-build --configuration Release
         $j | Select-Object -Property Id | Stop-Process

--- a/.github/workflows/BuildTestDeploy.yml
+++ b/.github/workflows/BuildTestDeploy.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Setup Dotnet sdk
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 2.1.x
+        dotnet-version: 6.0.x
                 
     - name: Test Linux
       if: contains(matrix.os, 'ubuntu')

--- a/NugetMetaPackage/NugetMetaPackage.csproj
+++ b/NugetMetaPackage/NugetMetaPackage.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/OVFFileConverterGUI/OVFFileConverterGUI.csproj
+++ b/OVFFileConverterGUI/OVFFileConverterGUI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/PlausibilityChecker/PlausibilityChecker/PlausibilityChecker.csproj
+++ b/PlausibilityChecker/PlausibilityChecker/PlausibilityChecker.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/PlausibilityChecker/PlausibilityCheckerUnitTests/PlausibilityCheckerUnitTests.csproj
+++ b/PlausibilityChecker/PlausibilityCheckerUnitTests/PlausibilityCheckerUnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net46</TargetFrameworks>
+    <TargetFrameworks>net6</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <Platforms>AnyCPU;x64</Platforms>

--- a/ReaderWriter/3rdPartyFormatAdapters/ASP/ASPFileReaderWriter/ASPFileReaderWriter.csproj
+++ b/ReaderWriter/3rdPartyFormatAdapters/ASP/ASPFileReaderWriter/ASPFileReaderWriter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 

--- a/ReaderWriter/3rdPartyFormatAdapters/CLI_ILT/ILTFileReaderAdapter/ILTFileReaderAdapter.csproj
+++ b/ReaderWriter/3rdPartyFormatAdapters/CLI_ILT/ILTFileReaderAdapter/ILTFileReaderAdapter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 

--- a/ReaderWriter/3rdPartyFormatAdapters/CLI_ILT/ILTFileReaderInterfaces/ILTFileReaderInterfaces.csproj
+++ b/ReaderWriter/3rdPartyFormatAdapters/CLI_ILT/ILTFileReaderInterfaces/ILTFileReaderInterfaces.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/ReaderWriter/3rdPartyFormatAdapters/CLI_ILT/iltFileReader/ILTFileReader.csproj
+++ b/ReaderWriter/3rdPartyFormatAdapters/CLI_ILT/iltFileReader/ILTFileReader.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 

--- a/ReaderWriter/AbstractReaderWriter/AbstractReaderWriter.csproj
+++ b/ReaderWriter/AbstractReaderWriter/AbstractReaderWriter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 

--- a/ReaderWriter/FileReaderWriterFactory/FileReaderWriterFactory.csproj
+++ b/ReaderWriter/FileReaderWriterFactory/FileReaderWriterFactory.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 

--- a/ReaderWriter/FileReaderWriterFactoryGRPCWrapper/FileReaderWriterFactoryGRPCWrapper.csproj
+++ b/ReaderWriter/FileReaderWriterFactoryGRPCWrapper/FileReaderWriterFactoryGRPCWrapper.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.1;net46</TargetFrameworks>
+    <TargetFrameworks>net6</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 

--- a/ReaderWriter/OVFDefinition/OVFDefinition.csproj
+++ b/ReaderWriter/OVFDefinition/OVFDefinition.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/ReaderWriter/OVFReaderWriter/OVFReaderWriter.csproj
+++ b/ReaderWriter/OVFReaderWriter/OVFReaderWriter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 

--- a/ReaderWriter/UnitTests/UnitTests.csproj
+++ b/ReaderWriter/UnitTests/UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net46</TargetFrameworks>
+    <TargetFrameworks>net6</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 


### PR DESCRIPTION
We had .net46 as lowest build-target for all libraries. However, .net46 will be EOL in 04/2022 (https://docs.microsoft.com/de-de/lifecycle/products/microsoft-net-framework).

All libraries now target netstandard2.0 with minimum supported .netFramework version being 4.6.1 (https://docs.microsoft.com/de-de/dotnet/standard/net-standard).

Targets for executables were .netcoreapp2.1, which is EOL since 08/2021, thus I upgraded to the newest LTS, net6 (https://dotnet.microsoft.com/platform/support/policy/dotnet-core).

@SebastianDirks do you have anything still depending on net46? Otherwise, it should be an easy upgrade.